### PR TITLE
Remove the possibility of a false positive.

### DIFF
--- a/AntiCurse/src/me/Skua/anticurse/AntiCurse.java
+++ b/AntiCurse/src/me/Skua/anticurse/AntiCurse.java
@@ -39,11 +39,11 @@ public class AntiCurse extends JavaPlugin implements Listener {
         Player p = e.getPlayer();
 	    
         for(String string : f) {
-        	 if(m.contains(string)) {
+            if(m.contains(" " + string + " ")) {
              	e.setCancelled(true);
             	p.sendMessage(ChatColor.RED + w);
         	  break;
             }
         }
-	}
+    }
 }


### PR DESCRIPTION
Doesn't detect words such as "glass" (contains ass).
